### PR TITLE
Add module map for framework

### DIFF
--- a/Instabug.framework/Modules/module.modulemap
+++ b/Instabug.framework/Modules/module.modulemap
@@ -1,0 +1,6 @@
+framework module Instabug {
+  umbrella header "Instabug.h"
+
+  export *
+  module * { export * }
+}


### PR DESCRIPTION
This allows users to directly import Instabug from Swift, without having
to do it in their bridging header.