### PR TITLE
Fix Carthage support

### DIFF
--- a/Carthage.json
+++ b/Carthage.json
@@ -2,6 +2,6 @@
   "7.1": "https://github.com/Instabug/Instabug-iOS/releases/download/7.1/Instabug.zip",
   "7.2": "https://github.com/Instabug/Instabug-iOS/releases/download/7.2/Instabug.zip",
   "7.2.1": "https://github.com/Instabug/Instabug-iOS/releases/download/7.2.1/Instabug.zip",
-  "7.2.2": "https://github.com/Instabug/Instabug-iOS/releases/download/7.2.2/Instabug.zip"
+  "7.2.2": "https://github.com/Instabug/Instabug-iOS/releases/download/7.2.2/Instabug.zip",
   "7.2.3": "https://github.com/Instabug/Instabug-iOS/releases/download/7.2.3/Instabug.zip"
 }


### PR DESCRIPTION
The Carthage JSON is missing a comma after the 7.2.2 line. Because the
JSON is invalid, Carthage can't parse it and attempting to
install/update Instabug fails.

Closes #146