### PR TITLE
Adding bot to 

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,0 +1,6 @@
+
+# Configuration for Lock Threads - https://github.com/dessant/lock-threads
+daysUntilLock: 45
+
+# Limit to issues only
+only: issues

--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -1,0 +1,12 @@
+# Configuration for probot-no-response - https://github.com/probot/no-response
+
+# Number of days of inactivity before an issue is closed for lack of response
+daysUntilClose: 7
+
+# Label requiring a response
+responseRequiredLabel: Pending Feedback
+# Comment to post when closing an Issue for lack of response. Set to `false` to disable
+closeComment: >
+  This issue has been automatically closed since we haven't heard back from
+  you. Please feel free to reopen the issue if you have more information
+  to add.


### PR DESCRIPTION
## Description of the change

- Adding a no-response bot that auto-close issues after 7 days of inactivity and another one that completely locks after 45 days

- For the no-response bot to run we need to add Pending Feedback label to the issues so we don't auto close the issue if it's pending on development

## Checklists
### Code review 
- [x]  This pull request has a descriptive title and information useful to a reviewer. 
